### PR TITLE
two winners changed to one

### DIFF
--- a/spec/04_game_spec.rb
+++ b/spec/04_game_spec.rb
@@ -110,7 +110,7 @@ describe 'Game' do
       game = Game.new
       game.board.cells = ["X", "O", "X",
                           "O", "O", "X",
-                          "O", "O", "X"]
+                          " ", " ", "X"]
 
       expect(game.won?).to contain_exactly(2, 5, 8)
     end


### PR DESCRIPTION
Board originally has two winners down the middle and right side. It's changed to one winner on the right side now.
Winning combos would be either [1,4,7] or [2,5,8]. So either could be returned as the winner depending on the order the combo. I had to move [2,5,8] ahead of [1,4,7] in WIN_COMBINATIONS to get it to pass.